### PR TITLE
bugfix: iteration_order > 0 fixes for loaders.py

### DIFF
--- a/loaders.py
+++ b/loaders.py
@@ -74,7 +74,7 @@ class CsvReader(object):
         # then features = states, actions, configs from current row (df)
         # labels = states from next row (lagged_df)
         else:
-            features_df = df[[episode_col, iteration_col] + feature_cols]
+            features_df = df[feature_cols]
             # TODO: check, is this always redundant?
             # i.e., is feature_cols is supset of augmented_cols
             features_df[augmented_cols] = df[augmented_cols]
@@ -97,7 +97,7 @@ class CsvReader(object):
         if iteration_order < 0:
             labels_df = df[[episode_col, iteration_col] + label_cols]
         else:
-            labels_df = lagged_df[label_cols]
+            labels_df = df[[episode_col, iteration_col]].join(lagged_df[label_cols])
         return labels_df.join(features_df)[vars_to_keep]
 
     def read(

--- a/loaders.py
+++ b/loaders.py
@@ -53,26 +53,37 @@ class CsvReader(object):
         # We group by episode and iteration indices to make dataset episodic
         df = df.sort_values(by=[episode_col, iteration_col])
         # Create a lagged dataframe for capturing inputs and outputs
+        # when iteration_order < 0, this will consist of the features
+        # since we are doing a shift-backwards
+        # when iteration_order > 0, this will consist of labels
+        # since we are doing a shift-forward
         lagged_df = df.groupby(by=episode_col, as_index=False).shift(
             iteration_order * -1
         )
         lagged_df = lagged_df.drop([iteration_col], axis=1)
 
-        features_df = lagged_df[feature_cols]
         # if iteration order is less than 1
         # then the actions, configs should not be lagged
         # only states should be lagged
+        # features = lagged_df[states] + df[actions, configs]
+        # labels = df[states]
         if iteration_order < 0:
+            features_df = lagged_df[feature_cols]
+            features_df[augmented_cols] = df[augmented_cols]
+        # if iteration order is greater than 1
+        # then features = states, actions, configs from current row (df)
+        # labels = states from next row (lagged_df)
+        else:
+            features_df = df[[episode_col, iteration_col] + feature_cols]
+            # TODO: check, is this always redundant?
+            # i.e., is feature_cols is supset of augmented_cols
             features_df[augmented_cols] = df[augmented_cols]
 
         # eventually we will join the labels_df with the features_df
         # if any columns are matching then rename them
         if bool(set(feature_cols) & set(label_cols)):
-            features_df = features_df.rename(columns=lambda x: lagger_str[:4] + "_" + x)
+            features_df = features_df.rename(columns=lambda x: "prev_" + x if x in label_cols else x)
 
-        logger.info(
-            f"{lagger_str.title()} states are being added to same row with prefix {lagger_str[:4]}"
-        )
         self.feature_cols = list(features_df.columns.values)
         self.label_cols = list(label_cols)
         logger.info(f"Feature columns are: {self.feature_cols}")
@@ -81,7 +92,11 @@ class CsvReader(object):
         vars_to_keep = (
             [episode_col, iteration_col] + self.feature_cols + self.label_cols
         )
-        return df.join(features_df)[vars_to_keep]
+        if iteration_order < 0:
+            labels_df = df[[episode_col, iteration_col] + label_cols]
+        else:
+            labels_df = lagged_df[label_cols]
+        return labels_df.join(features_df)[vars_to_keep]
 
     def read(
         self,

--- a/loaders.py
+++ b/loaders.py
@@ -82,7 +82,9 @@ class CsvReader(object):
         # eventually we will join the labels_df with the features_df
         # if any columns are matching then rename them
         if bool(set(feature_cols) & set(label_cols)):
-            features_df = features_df.rename(columns=lambda x: "prev_" + x if x in label_cols else x)
+            features_df = features_df.rename(
+                columns=lambda x: "prev_" + x if x in label_cols else x
+            )
 
         self.feature_cols = list(features_df.columns.values)
         self.label_cols = list(label_cols)


### PR DESCRIPTION
# Bugfix: loaders when logging {st,at}

PR Song: [Water No Get Enemy](https://www.youtube.com/watch?v=IQBC5URoF0s&ab_channel=ACghigo)

## What changed?

- `loaders.py`, specifically `CsvReader.split`, which now handles features_df and labels_df separately, and joins them at the end
- data.yaml tested: `cartpole_st_at.yaml`